### PR TITLE
Add variable bit shift for i64x2, i64x4, u64x2, u64x4 (#202)

### DIFF
--- a/src/i64x2_.rs
+++ b/src/i64x2_.rs
@@ -233,6 +233,39 @@ impl BitXor for i64x2 {
   }
 }
 
+/// Shifts lanes by the corresponding lane.
+///
+/// Bitwise shift-left; yields `self << mask(rhs)`, where mask removes any
+/// high-order bits of `rhs` that would cause the shift to exceed the bitwidth
+/// of the type. (same as `wrapping_shl`)
+impl Shl for i64x2 {
+  type Output = Self;
+
+  #[inline]
+  fn shl(self, rhs: Self) -> Self::Output {
+    pick! {
+      if #[cfg(target_feature="avx2")] {
+        // mask the shift count to 63 to have same behavior on all platforms
+        let shift_by = rhs & Self::splat(63);
+        Self { sse: shl_each_u64_m128i(self.sse, shift_by.sse) }
+      } else if #[cfg(all(target_feature="neon", target_arch="aarch64"))] {
+        unsafe {
+          // mask the shift count to 63 to have same behavior on all platforms
+          let shift_by = vandq_s64(rhs.neon, vmovq_n_s64(63));
+          Self { neon: vshlq_s64(self.neon, shift_by) }
+        }
+      } else {
+        let arr: [i64; 2] = cast(self);
+        let rhs: [i64; 2] = cast(rhs);
+        cast([
+          arr[0].wrapping_shl(rhs[0] as u32),
+          arr[1].wrapping_shl(rhs[1] as u32),
+        ])
+      }
+    }
+  }
+}
+
 macro_rules! impl_shl_t_for_i64x2 {
   ($($shift_type:ty),+ $(,)?) => {
     $(impl Shl<$shift_type> for i64x2 {
@@ -261,6 +294,36 @@ macro_rules! impl_shl_t_for_i64x2 {
   };
 }
 impl_shl_t_for_i64x2!(i8, u8, i16, u16, i32, u32, i64, u64, i128, u128);
+
+/// Shifts lanes by the corresponding lane.
+///
+/// Bitwise shift-right; yields `self >> mask(rhs)`, where mask removes any
+/// high-order bits of `rhs` that would cause the shift to exceed the bitwidth
+/// of the type. (same as `wrapping_shr`)
+impl Shr for i64x2 {
+  type Output = Self;
+
+  #[inline]
+  fn shr(self, rhs: Self) -> Self::Output {
+    pick! {
+      if #[cfg(all(target_feature="neon", target_arch="aarch64"))] {
+        unsafe {
+          // mask the shift count to 63 to have same behavior on all platforms
+          // no right shift, have to pass negative value to left shift on neon
+          let shift_by = vnegq_s64(vandq_s64(rhs.neon, vmovq_n_s64(63)));
+          Self { neon: vshlq_s64(self.neon, shift_by) }
+        }
+      } else {
+        let arr: [i64; 2] = cast(self);
+        let rhs: [i64; 2] = cast(rhs);
+        cast([
+          arr[0].wrapping_shr(rhs[0] as u32),
+          arr[1].wrapping_shr(rhs[1] as u32),
+        ])
+      }
+    }
+  }
+}
 
 macro_rules! impl_shr_t_for_i64x2 {
   ($($shift_type:ty),+ $(,)?) => {

--- a/src/i64x4_.rs
+++ b/src/i64x4_.rs
@@ -171,6 +171,31 @@ impl BitXor for i64x4 {
   }
 }
 
+/// Shifts lanes by the corresponding lane.
+///
+/// Bitwise shift-left; yields `self << mask(rhs)`, where mask removes any
+/// high-order bits of `rhs` that would cause the shift to exceed the bitwidth
+/// of the type. (same as `wrapping_shl`)
+impl Shl for i64x4 {
+  type Output = Self;
+
+  #[inline]
+  fn shl(self, rhs: Self) -> Self::Output {
+    pick! {
+      if #[cfg(target_feature="avx2")] {
+        // mask the shift count to 63 to have same behavior on all platforms
+        let shift_by = rhs & Self::splat(63);
+        Self { avx2: shl_each_u64_m256i(self.avx2, shift_by.avx2) }
+      } else {
+        Self {
+          a : self.a.shl(rhs.a),
+          b : self.b.shl(rhs.b),
+        }
+      }
+    }
+  }
+}
+
 macro_rules! impl_shl_t_for_i64x4 {
   ($($shift_type:ty),+ $(,)?) => {
     $(impl Shl<$shift_type> for i64x4 {
@@ -194,6 +219,36 @@ macro_rules! impl_shl_t_for_i64x4 {
   };
 }
 impl_shl_t_for_i64x4!(i8, u8, i16, u16, i32, u32, i64, u64, i128, u128);
+
+/// Shifts lanes by the corresponding lane.
+///
+/// Bitwise shift-right; yields `self >> mask(rhs)`, where mask removes any
+/// high-order bits of `rhs` that would cause the shift to exceed the bitwidth
+/// of the type. (same as `wrapping_shr`)
+impl Shr for i64x4 {
+  type Output = Self;
+
+  #[inline]
+  fn shr(self, rhs: Self) -> Self::Output {
+    pick! {
+      if #[cfg(target_feature="avx2")] {
+        let arr: [i64; 4] = cast(self);
+        let rhs: [i64; 4] = cast(rhs);
+        cast([
+          arr[0].wrapping_shr(rhs[0] as u32),
+          arr[1].wrapping_shr(rhs[1] as u32),
+          arr[2].wrapping_shr(rhs[2] as u32),
+          arr[3].wrapping_shr(rhs[3] as u32),
+        ])
+      } else {
+        Self {
+          a : self.a.shr(rhs.a),
+          b : self.b.shr(rhs.b),
+        }
+      }
+    }
+  }
+}
 
 macro_rules! impl_shr_t_for_i64x4 {
   ($($shift_type:ty),+ $(,)?) => {

--- a/src/u64x2_.rs
+++ b/src/u64x2_.rs
@@ -233,6 +233,39 @@ impl BitXor for u64x2 {
   }
 }
 
+/// Shifts lanes by the corresponding lane.
+///
+/// Bitwise shift-left; yields `self << mask(rhs)`, where mask removes any
+/// high-order bits of `rhs` that would cause the shift to exceed the bitwidth
+/// of the type. (same as `wrapping_shl`)
+impl Shl for u64x2 {
+  type Output = Self;
+
+  #[inline]
+  fn shl(self, rhs: Self) -> Self::Output {
+    pick! {
+      if #[cfg(target_feature="avx2")] {
+        // mask the shift count to 63 to have same behavior on all platforms
+        let shift_by = rhs & Self::splat(63);
+        Self { sse: shl_each_u64_m128i(self.sse, shift_by.sse) }
+      } else if #[cfg(all(target_feature="neon", target_arch="aarch64"))] {
+        unsafe {
+          // mask the shift count to 63 to have same behavior on all platforms
+          let shift_by = vreinterpretq_s64_u64(vandq_u64(rhs.neon, vmovq_n_u64(63)));
+          Self { neon: vshlq_u64(self.neon, shift_by) }
+        }
+      } else {
+        let arr: [u64; 2] = cast(self);
+        let rhs: [u64; 2] = cast(rhs);
+        cast([
+          arr[0].wrapping_shl(rhs[0] as u32),
+          arr[1].wrapping_shl(rhs[1] as u32),
+        ])
+      }
+    }
+  }
+}
+
 macro_rules! impl_shl_t_for_u64x2 {
   ($($shift_type:ty),+ $(,)?) => {
     $(impl Shl<$shift_type> for u64x2 {
@@ -261,6 +294,40 @@ macro_rules! impl_shl_t_for_u64x2 {
   };
 }
 impl_shl_t_for_u64x2!(i8, u8, i16, u16, i32, u32, i64, u64, i128, u128);
+
+/// Shifts lanes by the corresponding lane.
+///
+/// Bitwise shift-right; yields `self >> mask(rhs)`, where mask removes any
+/// high-order bits of `rhs` that would cause the shift to exceed the bitwidth
+/// of the type. (same as `wrapping_shr`)
+impl Shr for u64x2 {
+  type Output = Self;
+
+  #[inline]
+  fn shr(self, rhs: Self) -> Self::Output {
+    pick! {
+      if #[cfg(target_feature="avx2")] {
+        // mask the shift count to 63 to have same behavior on all platforms
+        let shift_by = rhs & Self::splat(63);
+        Self { sse: shr_each_u64_m128i(self.sse, shift_by.sse) }
+      } else if #[cfg(all(target_feature="neon", target_arch="aarch64"))] {
+        unsafe {
+          // mask the shift count to 63 to have same behavior on all platforms
+          // no right shift, have to pass negative value to left shift on neon
+          let shift_by = vnegq_s64(vreinterpretq_s64_u64(vandq_u64(rhs.neon, vmovq_n_u64(63))));
+          Self { neon: vshlq_u64(self.neon, shift_by) }
+        }
+      } else {
+        let arr: [u64; 2] = cast(self);
+        let rhs: [u64; 2] = cast(rhs);
+        cast([
+          arr[0].wrapping_shr(rhs[0] as u32),
+          arr[1].wrapping_shr(rhs[1] as u32),
+        ])
+      }
+    }
+  }
+}
 
 macro_rules! impl_shr_t_for_u64x2 {
   ($($shift_type:ty),+ $(,)?) => {

--- a/src/u64x4_.rs
+++ b/src/u64x4_.rs
@@ -171,6 +171,31 @@ impl BitXor for u64x4 {
   }
 }
 
+/// Shifts lanes by the corresponding lane.
+///
+/// Bitwise shift-left; yields `self << mask(rhs)`, where mask removes any
+/// high-order bits of `rhs` that would cause the shift to exceed the bitwidth
+/// of the type. (same as `wrapping_shl`)
+impl Shl for u64x4 {
+  type Output = Self;
+
+  #[inline]
+  fn shl(self, rhs: Self) -> Self::Output {
+    pick! {
+      if #[cfg(target_feature="avx2")] {
+        // mask the shift count to 63 to have same behavior on all platforms
+        let shift_by = rhs & Self::splat(63);
+        Self { avx2: shl_each_u64_m256i(self.avx2, shift_by.avx2) }
+      } else {
+        Self {
+          a : self.a.shl(rhs.a),
+          b : self.b.shl(rhs.b),
+        }
+      }
+    }
+  }
+}
+
 macro_rules! impl_shl_t_for_u64x4 {
   ($($shift_type:ty),+ $(,)?) => {
     $(impl Shl<$shift_type> for u64x4 {
@@ -194,6 +219,31 @@ macro_rules! impl_shl_t_for_u64x4 {
   };
 }
 impl_shl_t_for_u64x4!(i8, u8, i16, u16, i32, u32, i64, u64, i128, u128);
+
+/// Shifts lanes by the corresponding lane.
+///
+/// Bitwise shift-right; yields `self >> mask(rhs)`, where mask removes any
+/// high-order bits of `rhs` that would cause the shift to exceed the bitwidth
+/// of the type. (same as `wrapping_shr`)
+impl Shr for u64x4 {
+  type Output = Self;
+
+  #[inline]
+  fn shr(self, rhs: Self) -> Self::Output {
+    pick! {
+      if #[cfg(target_feature="avx2")] {
+        // mask the shift count to 63 to have same behavior on all platforms
+        let shift_by = rhs & Self::splat(63);
+        Self { avx2: shr_each_u64_m256i(self.avx2, shift_by.avx2) }
+      } else {
+        Self {
+          a : self.a.shr(rhs.a),
+          b : self.b.shr(rhs.b),
+        }
+      }
+    }
+  }
+}
 
 macro_rules! impl_shr_t_for_u64x4 {
   ($($shift_type:ty),+ $(,)?) => {

--- a/tests/all_tests/t_i64x2.rs
+++ b/tests/all_tests/t_i64x2.rs
@@ -66,12 +66,40 @@ fn impl_bitxor_for_i64x2() {
 }
 
 #[test]
+fn impl_shl_each_for_i64x2() {
+  let a = i64x2::from([i64::MAX - 1, -1]);
+  let shift = i64x2::from([2, 65 /* test masking behavior */]);
+  let expected = i64x2::from([(i64::MAX - 1) << 2, -1 << 1]);
+  let actual = a << shift;
+  assert_eq!(expected, actual);
+
+  crate::test_random_vector_vs_scalar(
+    |a: i64x2, b| a << b,
+    |a, b| a.wrapping_shl(b as u32),
+  );
+}
+
+#[test]
 fn impl_shl_for_i64x2() {
   let a = i64x2::from([i64::MAX - 1, i64::MAX - 1]);
   let b = 2;
   let expected = i64x2::from([(i64::MAX - 1) << 2, (i64::MAX - 1) << 2]);
   let actual = a << b;
   assert_eq!(expected, actual);
+}
+
+#[test]
+fn impl_shr_each_for_i64x2() {
+  let a = i64x2::from([i64::MAX - 1, -1]);
+  let shift = i64x2::from([2, 65 /* test masking behavior */]);
+  let expected = i64x2::from([(i64::MAX - 1) >> 2, -1 >> 1]);
+  let actual = a >> shift;
+  assert_eq!(expected, actual);
+
+  crate::test_random_vector_vs_scalar(
+    |a: i64x2, b| a >> b,
+    |a, b| a.wrapping_shr(b as u32),
+  );
 }
 
 #[test]

--- a/tests/all_tests/t_i64x4.rs
+++ b/tests/all_tests/t_i64x4.rs
@@ -72,6 +72,20 @@ fn impl_bitxor_for_i64x4() {
 }
 
 #[test]
+fn impl_shl_each_for_i64x4() {
+  let a = i64x4::from([i64::MAX - 1, -1, 0, -1]);
+  let shift = i64x4::from([2, 3, 4, 65 /* test masking behavior */]);
+  let expected = i64x4::from([(i64::MAX - 1) << 2, -1 << 3, 0 << 4, -1 << 1]);
+  let actual = a << shift;
+  assert_eq!(expected, actual);
+
+  crate::test_random_vector_vs_scalar(
+    |a: i64x4, b| a << b,
+    |a, b| a.wrapping_shl(b as u32),
+  );
+}
+
+#[test]
 fn impl_shl_for_i64x4() {
   let a = i64x4::from([i64::MAX - 1, i64::MAX - 1, 65535, 0]);
   let b = 2;
@@ -79,6 +93,20 @@ fn impl_shl_for_i64x4() {
     i64x4::from([(i64::MAX - 1) << 2, (i64::MAX - 1) << 2, 65535 << 2, 0 << 2]);
   let actual = a << b;
   assert_eq!(expected, actual);
+}
+
+#[test]
+fn impl_shr_each_for_i64x4() {
+  let a = i64x4::from([i64::MAX - 1, -1, 0, -1]);
+  let shift = i64x4::from([2, 3, 4, 65 /* test masking behavior */]);
+  let expected = i64x4::from([(i64::MAX - 1) >> 2, -1 >> 3, 0 >> 4, -1 >> 1]);
+  let actual = a >> shift;
+  assert_eq!(expected, actual);
+
+  crate::test_random_vector_vs_scalar(
+    |a: i64x4, b| a >> b,
+    |a, b| a.wrapping_shr(b as u32),
+  );
 }
 
 #[test]

--- a/tests/all_tests/t_u64x2.rs
+++ b/tests/all_tests/t_u64x2.rs
@@ -72,12 +72,40 @@ fn impl_bitxor_for_u64x2() {
 }
 
 #[test]
+fn impl_shl_each_for_u64x2() {
+  let a = u64x2::from([u64::MAX - 1, u64::MAX]);
+  let shift = u64x2::from([2, 65 /* test masking behavior */]);
+  let expected = u64x2::from([(u64::MAX - 1) << 2, u64::MAX << 1]);
+  let actual = a << shift;
+  assert_eq!(expected, actual);
+
+  crate::test_random_vector_vs_scalar(
+    |a: u64x2, b| a << b,
+    |a, b| a.wrapping_shl(b as u32),
+  );
+}
+
+#[test]
 fn impl_shl_for_u64x2() {
   let a = u64x2::from([u64::MAX - 1, u64::MAX - 1]);
   let b = 2;
   let expected = u64x2::from([(u64::MAX - 1) << 2, (u64::MAX - 1) << 2]);
   let actual = a << b;
   assert_eq!(expected, actual);
+}
+
+#[test]
+fn impl_shr_each_for_u64x2() {
+  let a = u64x2::from([u64::MAX - 1, u64::MAX]);
+  let shift = u64x2::from([2, 65 /* test masking behavior */]);
+  let expected = u64x2::from([(u64::MAX - 1) >> 2, u64::MAX >> 1]);
+  let actual = a >> shift;
+  assert_eq!(expected, actual);
+
+  crate::test_random_vector_vs_scalar(
+    |a: u64x2, b| a >> b,
+    |a, b| a.wrapping_shr(b as u32),
+  );
 }
 
 #[test]

--- a/tests/all_tests/t_u64x4.rs
+++ b/tests/all_tests/t_u64x4.rs
@@ -68,6 +68,21 @@ fn impl_bitxor_for_u64x4() {
 }
 
 #[test]
+fn impl_shl_each_for_u64x4() {
+  let a = u64x4::from([u64::MAX - 1, u64::MAX, 0, u64::MAX]);
+  let shift = u64x4::from([2, 3, 4, 65 /* test masking behavior */]);
+  let expected =
+    u64x4::from([(u64::MAX - 1) << 2, u64::MAX << 3, 0 << 4, u64::MAX << 1]);
+  let actual = a << shift;
+  assert_eq!(expected, actual);
+
+  crate::test_random_vector_vs_scalar(
+    |a: u64x4, b| a << b,
+    |a, b| a.wrapping_shl(b as u32),
+  );
+}
+
+#[test]
 fn impl_shl_for_u64x4() {
   let a = u64x4::from([u64::MAX - 1, u64::MAX - 1, 65535, 0]);
   let b = 2;
@@ -75,6 +90,21 @@ fn impl_shl_for_u64x4() {
     u64x4::from([(u64::MAX - 1) << 2, (u64::MAX - 1) << 2, 65535 << 2, 0 << 2]);
   let actual = a << b;
   assert_eq!(expected, actual);
+}
+
+#[test]
+fn impl_shr_each_for_u64x4() {
+  let a = u64x4::from([u64::MAX - 1, u64::MAX, 0, u64::MAX]);
+  let shift = u64x4::from([2, 3, 4, 65 /* test masking behavior */]);
+  let expected =
+    u64x4::from([(u64::MAX - 1) >> 2, u64::MAX >> 3, 0 >> 4, u64::MAX >> 1]);
+  let actual = a >> shift;
+  assert_eq!(expected, actual);
+
+  crate::test_random_vector_vs_scalar(
+    |a: u64x4, b| a >> b,
+    |a, b| a.wrapping_shr(b as u32),
+  );
 }
 
 #[test]


### PR DESCRIPTION
* Add variable bit shift for i64x2, i64x4, u64x2, u64x4

* fix

* fix

* nit

* auto vectorized

* Use self::splat

* nit

* nit

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added per-lane left/right shift operators for 64-bit lane vectors (2- and 4-wide), with consistent masking/wrapping across platforms.
  - Supports scalar shift counts across common integer types.
- Bug Fixes
  - Corrected a macro to properly generate left-shift implementations.
- Documentation
  - Expanded docs explaining shift semantics and masking behavior.
- Tests
  - Added per-lane shift tests (including edge cases like counts ≥ 64) and random vector-vs-scalar validations to ensure correctness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->